### PR TITLE
refactor(tree.js)

### DIFF
--- a/public/tree.js
+++ b/public/tree.js
@@ -44,7 +44,7 @@ If.prototype.update = function(value) {
   if (this.condition !== newCondition) {
     this.condition = newCondition;
     if (this.component) {
-      this.component.element.parentNode.removeChild(this.component.element);
+      this.component.element.remove();
       this.component = null;
     }
     if (this.condition) {


### PR DESCRIPTION
Using `element.remove()` is simpler than using `element.parentNode.removeChild(element)`.

Double checked in Angular2 repo, it's correct there...