### PR TITLE
Open a new browser window for every benchmark

### DIFF
--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -26,6 +26,22 @@ exports.config = {
     }).listen('8080', 'localhost');
   },
 
+  onPrepare: function() {
+    // open a new browser for every benchmark
+    var originalBrowser = browser;
+    var _tmpBrowser;
+    beforeEach(function() {
+      global.browser = originalBrowser.forkNewDriverInstance();
+      global.element = global.browser.element;
+      global.$ = global.browser.$;
+      global.$$ = global.browser.$$;
+    });
+    afterEach(function() {
+      global.browser.quit();
+      global.browser = originalBrowser;
+    });
+  },
+
   jasmineNodeOpts: {
     showColors: true,
     defaultTimeoutInterval: 30000


### PR DESCRIPTION
Otherwise numbers can get skewed as chrome keeps JIT data over page reloads.