### PR TITLE
fix benchpress metric name

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "jeffbcross",
   "license": "Apache 2",
   "dependencies": {
-    "benchpress": "^2.0.0-alpha.12",
+    "benchpress": "^2.0.0-alpha.25",
     "http-server": "^0.7.5",
     "protractor": "^1.7.0"
   }

--- a/tree_benchmark.spec.js
+++ b/tree_benchmark.spec.js
@@ -7,7 +7,7 @@ var runner = new benchpress.Runner([
   //use 10 samples to calculate slope regression
   benchpress.bind(benchpress.RegressionSlopeValidator.SAMPLE_SIZE).toValue(20),
   //use the script metric to calculate slope regression
-  benchpress.bind(benchpress.RegressionSlopeValidator.METRIC).toValue('script'),
+  benchpress.bind(benchpress.RegressionSlopeValidator.METRIC).toValue('scriptTime'),
   benchpress.bind(benchpress.Options.FORCE_GC).toValue(true)
 ]);
 


### PR DESCRIPTION
This fixes an issue in tree_benchmark.spec.js where the METRIC value should be `scriptTime`, not `script`.

It also updates the benchpress version.