### PR TITLE
Adds reflect-metadata require to tree_benchmark.spec.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "benchpress": "^2.0.0-alpha.25",
     "http-server": "^0.7.5",
-    "protractor": "^1.7.0"
+    "protractor": "^1.7.0",
+    "reflect-metadata": "^0.1.0"
   }
 }

--- a/tree_benchmark.spec.js
+++ b/tree_benchmark.spec.js
@@ -1,3 +1,4 @@
+var reflect = require('reflect-metadata');
 var benchpress = require('benchpress');
 var runner = new benchpress.Runner([
   //use protractor as Webdriver client


### PR DESCRIPTION
Corrects issue #4  compiling and running the benchmark